### PR TITLE
Use reduced blanking modelines in CVT to resize for usage with Xorg with nvidia driver

### DIFF
--- a/src/selkies_gstreamer/resize.py
+++ b/src/selkies_gstreamer/resize.py
@@ -130,7 +130,7 @@ def generate_xrandr_gtf_modeline(res):
     else:
         raise Exception("unsupported input resolution format: {}".format(res))
 
-    with os.popen('cvt ' + gtf_res) as pipe:
+    with os.popen('cvt -r ' + gtf_res) as pipe:
         for line in pipe:
             modeline_ma = re.match(modeline_pat, line.strip())
             if modeline_ma:


### PR DESCRIPTION
The reason I would prefer this is: 1. No recent NVIDIA GPU has a CRT output, they are all DFP, and thus this represents the resolution to signal ratio closer to the NVIDIA driver modeline. 2. Because of this, not using `cvt -r` with a real GPU using the nvidia driver in Xorg leads to supporting lower resolutions than advertised by the GPU. 3. The `ConnectedMonitor` setting when the output is set to HDMI without `cvt -r` prevents supporting 1920x1200, along with other less supported resolutions than expected in different situations when resizing.