### PR TITLE
Add alternative triggers for each workflow

### DIFF
--- a/.github/workflows/build_and_publish_all_images.yaml
+++ b/.github/workflows/build_and_publish_all_images.yaml
@@ -1,6 +1,12 @@
 name: Build & publish all images
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/**"
+  workflow_dispatch:
 
 jobs:
   # Note: When modifying this job, copy modifications to all other workflows' image jobs.

--- a/.github/workflows/build_and_publish_changed_images.yaml
+++ b/.github/workflows/build_and_publish_changed_images.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   # Note: When modifying this job, copy modifications to all other workflows' image jobs.

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   get_semver:


### PR DESCRIPTION
This will allow us to
- automatically trigger the "publish all image" workflow (on any automation change, since we won't know what images should be rebuilt)
- manually trigger the "publish changed images" workflow
- manually trigger "publish release" workflow