### PR TITLE
Remote cursors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-buster
+FROM python:3-jessie
 
 LABEL maintainer "https://github.com/danisla"
 

--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -54,8 +54,10 @@ RUN \
         curl \
         jq \
         xvfb \
-        icewm \
-        xterm \
+        xfce4 \
+        xfce4-terminal \
+        adwaita-icon-theme-full \
+        dbus-x11 \
         x11-apps \
         firefox && \
     rm -rf /var/lib/apt/lists/*
@@ -109,7 +111,7 @@ Xvfb -screen :0 8192x4096x24 +extension RANDR +extension GLX +extension MIT-SHM 
 until [[ -S /tmp/.X11-unix/X0 ]]; do sleep 1; done && echo 'X Server is ready'\n\
 sudo /usr/bin/pulseaudio -k >/dev/null 2>&1\n\
 sudo /usr/bin/pulseaudio --daemonize --system --verbose --log-target=file:/tmp/pulseaudio.log --realtime=true --disallow-exit -L 'module-native-protocol-tcp auth-ip-acl=127.0.0.0/8 port=4713 auth-anonymous=1'\n\
-icewm-session &\n\
+xfce4-session &\n\
 export WEBRTC_ENCODER=\${WEBRTC_ENCODER:-x264enc}\n\
 export WEBRTC_ENABLE_RESIZE=\${WEBRTC_ENABLE_RESIZE:-true}\n\
 export JSON_CONFIG=/tmp/selkies.json\n\

--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -41,7 +41,8 @@ RUN \
         pulseaudio \
         libpulse0 \
         libpangocairo-1.0-0 \
-        libgirepository1.0-dev && \
+        libgirepository1.0-dev \
+        git && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt

--- a/addons/gst-web/src/app.js
+++ b/addons/gst-web/src/app.js
@@ -501,6 +501,17 @@ webrtc.onclipboardcontent = (content) => {
     }
 }
 
+var _cursor_cache = new Map();
+webrtc.oncursorchange = (handle, curdata, hotspot) => {
+    if (!_cursor_cache.has(handle)) {
+        // Add cursor to cache.
+        const cursor_url = "url('data:image/png;base64," + curdata + "')";
+        this._cursor_cache.set(handle, cursor_url);
+    }
+    var cursor_url = this._cursor_cache.get(handle);
+    videoElement.style.cursor = cursor_url + ", auto";
+}
+
 webrtc.onsystemaction = (action) => {
     webrtc._setStatus("Executing system action: " + action);
     if (action === 'reload') {

--- a/addons/gst-web/src/input.js
+++ b/addons/gst-web/src/input.js
@@ -158,6 +158,8 @@ class Input {
         ];
 
         this.send(toks.join(","));
+
+        event.preventDefault();
     }
 
     /**

--- a/addons/gst-web/src/webrtc.js
+++ b/addons/gst-web/src/webrtc.js
@@ -138,6 +138,11 @@ class WebRTCDemo {
         /**
          * @type {function}
          */
+         this.oncursorchange = null;
+
+        /**
+         * @type {function}
+         */
         this.onsystemstats = null;
 
         // Bind signalling server callbacks.
@@ -348,6 +353,14 @@ class WebRTCDemo {
                 if (this.onclipboardcontent !== null) {
                     this.onclipboardcontent(content);
                 }
+            }
+        } else if (msg.type === 'cursor') {
+            if (this.oncursorchange !== null && msg.data !== null) {
+                var curdata = msg.data.curdata;
+                var handle = msg.data.handle;
+                var hotspot = msg.data.hotspot;
+                this._setDebug(`received new cursor contents, handle: ${handle}, hotspot: ${JSON.stringify(hotspot)} image length: ${curdata.length}`);
+                this.oncursorchange(handle, curdata, hotspot);
             }
         } else if (msg.type === 'system') {
             if (msg.action !== null) {

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ python_requires = >=3.6
 install_requires =
     websockets
     basicauth
-    xlib
     gputil
     python-uinput
     prometheus_client
@@ -31,6 +30,10 @@ install_requires =
     pynput
     psutil
     watchdog
+    Pillow
+    # TODO: remove this fork after PR is merged and is in release.
+    # https://github.com/python-xlib/python-xlib/pull/218
+    python-xlib @ git+https://github.com/selkies-project/python-xlib@add-xfixes-cursor
 
 [options.packages.find]
 where = src

--- a/src/selkies_gstreamer/gstwebrtc_app.py
+++ b/src/selkies_gstreamer/gstwebrtc_app.py
@@ -75,6 +75,7 @@ class GSTWebRTCApp:
 
         self.pipeline = None
         self.ximagesrc = None
+        self.last_cursor_sent = None
 
     def stop_ximagesrc(self):
         """Helper function to stop the ximagesrc, useful when resizing
@@ -746,6 +747,11 @@ class GSTWebRTCApp:
     def send_clipboard_data(self, data):
         self.__send_data_channel_message(
             "clipboard", {"content": base64.b64encode(data.encode()).decode("utf-8")})
+
+    def send_cursor_data(self, data):
+        self.last_cursor_sent = data
+        self.__send_data_channel_message(
+            "cursor", data)
 
     def send_gpu_stats(self, load, memory_total, memory_used):
         """Sends GPU stats to the data channel


### PR DESCRIPTION
## Remote cursors feature
- Default is enabled, disable by setting env var `WEBRTC_ENABLE_CURSORS=false`
- Set `DEBUG_CURSORS` to enable server-side cursor change logging and save cursors to png files.
- Cursors are resized to 24x24 on the server-side.
- New data channel message with type named `cursor` containing changed cursor data.
- Uses [fork for python-xlib](https://github.com/selkies-project/python-xlib/tree/add-xfixes-cursor) to get cursor notify events.

## Other notable changes
- Migrated example image from icewm to xfce4

----
Closes #14 