### PR TITLE
Fix overflow in UI and fix for Safari

### DIFF
--- a/addons/gst-web/src/app.js
+++ b/addons/gst-web/src/app.js
@@ -618,21 +618,24 @@ webrtc.onsystemstats = (stats) => {
     if (stats.mem_used !== undefined) app.serverMemoryUsed = stats.mem_used;
 }
 
-navigator.permissions.query({
-    name: 'clipboard-read'
-}).then(permissionStatus => {
-    // Will be 'granted', 'denied' or 'prompt':
-    if (permissionStatus.state === 'granted') {
-        app.clipboardStatus = 'enabled';
-    }
-
-    // Listen for changes to the permission state
-    permissionStatus.onchange = () => {
+// Safari withou Permission-Api enabled fails here
+if (navigator.permissions) {
+    navigator.permissions.query({
+        name: 'clipboard-read'
+    }).then(permissionStatus => {
+        // Will be 'granted', 'denied' or 'prompt':
         if (permissionStatus.state === 'granted') {
             app.clipboardStatus = 'enabled';
         }
-    };
-});
+
+        // Listen for changes to the permission state
+        permissionStatus.onchange = () => {
+            if (permissionStatus.state === 'granted') {
+                app.clipboardStatus = 'enabled';
+            }
+        };
+    });
+}
 
 // Check if editing is allowed.
 var checkPublishing = () => {

--- a/addons/gst-web/src/css/vuetify.css
+++ b/addons/gst-web/src/css/vuetify.css
@@ -2177,7 +2177,7 @@
 }
 html {
   box-sizing: border-box;
-  overflow-y: scroll; /* All browsers without overlaying scrollbars */
+  overflow-y: hidden; /* All browsers without overlaying scrollbars */
   -webkit-text-size-adjust: 100%; /* iOS 8+ */
 }
 *,
@@ -3390,7 +3390,8 @@ p {
           backface-visibility: hidden;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
+  max-height: 100%;
   max-width: 100%;
   position: relative;
 }

--- a/addons/gst-web/src/css/vuetify.css
+++ b/addons/gst-web/src/css/vuetify.css
@@ -3391,7 +3391,7 @@ p {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  max-height: 100%;
+  max-height: -webkit-fill-available;
   max-width: 100%;
   position: relative;
 }


### PR DESCRIPTION
Should fix overflow in UI if, e.g., bookmarks bar is visible. Also fix for Safari if Permissions api is not enabled.

Please test, if UI issues are gone.