### PR TITLE
Add level-asymmetry-allowed with profile-level-id to fix Firefox

### DIFF
--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -105,7 +105,7 @@ RUN pip3 install /opt/${PYPI_PACKAGE}-${PACKAGE_VERSION}-py3-none-any.whl
 # Remove this and uncommend line in setup.cfg after this PR is merged and in release:
 # https://github.com/python-xlib/python-xlib/pull/218
 RUN if [ "${UBUNTU_RELEASE}" != "18.04" ] ; then \
-    pip3 install -e git+https://github.com/selkies-project/python-xlib.git@add-xfixes-cursor#egg=python-xlib ; fi
+    pip3 install --upgrade --force-reinstall https://github.com/python-xlib/python-xlib/archive/master.zip ; fi
 
 # Setup global bashrc to configure gstreamer environment
 RUN echo 'export DISPLAY=:0' \

--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -497,8 +497,8 @@ def main():
     logger.info("initial server RTC config: {}".format(rtc_config))
 
     # Extract args
-    enable_audio = args.enable_audio == "true"
-    enable_resize = args.enable_resize == "true"
+    enable_audio = args.enable_audio.lower() == "true"
+    enable_resize = args.enable_resize.lower() == "true"
     curr_fps = int(args.framerate)
     curr_video_bitrate = int(args.video_bitrate)
     curr_audio_bitrate = int(args.audio_bitrate)

--- a/src/selkies_gstreamer/webrtc_signalling.py
+++ b/src/selkies_gstreamer/webrtc_signalling.py
@@ -25,8 +25,8 @@ Interfaces with signalling server found at:
   https://github.com/centricular/gstwebrtc-demos/tree/master/signalling
 
     Usage example:
-    from webrtc_signalling import WebRTCSinalling
-    signalling = WebRTCSinalling(server, id, peer_id)
+    from webrtc_signalling import WebRTCSignalling
+    signalling = WebRTCSignalling(server, id, peer_id)
     signalling.on_connect = lambda: signalling.setup_call()
     signalling.connect()
     signalling.start()


### PR DESCRIPTION
`level-asymmetry-allowed` allows profile level mismatch. Other minor fixes applied.
Please merge this before #44 as this is a PR for a PR.