### PR TITLE
istio api to v1beta1

### DIFF
--- a/infra/gke/manifests/coturn-vm/coturn-gateway.yaml
+++ b/infra/gke/manifests/coturn-vm/coturn-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: coturn

--- a/infra/gke/manifests/coturn-vm/coturn-web-virtualservice.yaml
+++ b/infra/gke/manifests/coturn-vm/coturn-web-virtualservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: coturn-web

--- a/infra/gke/manifests/coturn/coturn-gateway.yaml
+++ b/infra/gke/manifests/coturn/coturn-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: coturn

--- a/infra/gke/manifests/coturn/coturn-web-virtualservice.yaml
+++ b/infra/gke/manifests/coturn/coturn-web-virtualservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: coturn-web

--- a/infra/gke/manifests/selkies-gstreamer/selkies-gstreamer-gateway.yaml
+++ b/infra/gke/manifests/selkies-gstreamer/selkies-gstreamer-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: selkies-gstreamer

--- a/infra/gke/manifests/selkies-gstreamer/selkies-gstreamer-virtualservice.yaml
+++ b/infra/gke/manifests/selkies-gstreamer/selkies-gstreamer-virtualservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: selkies-gstreamer


### PR DESCRIPTION
- istio api upgrade for `networking.istio.io` from `v1alpha3` to `v1beta1`